### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 0.3.1
+
+2018-01-06
+
+* Fix: HttpURLConnectionClient doesn't work on Android when the API level is lower than 24.
 
 ## Version 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Download the latest jar
 for gradle users: (If you use gradle versioned 2.x, specify 'compile' instead of 'implmentaion')
 
 ```gradle
-implementation 'com.ryuta46:nem-kotlin:0.2.0'
+implementation 'com.ryuta46:nem-kotlin:0.3.1'
 ```
 
 
@@ -34,7 +34,7 @@ for maven users:
 <dependency>
   <groupId>com.ryuta46</groupId>
   <artifactId>nem-kotlin</artifactId>
-  <version>0.2.0</version>
+  <version>0.3.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ryuta46</groupId>
     <artifactId>nem-kotlin</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.1</version>
 
     <name>nem-kotlin</name>
     <description>nem-kotlin is client library for easy use of NEM(New Economy Movement) API.</description>

--- a/samples/simple-android/app/build.gradle
+++ b/samples/simple-android/app/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     kapt 'com.jakewharton:butterknife-compiler:8.8.1'
 
     // nem-kotlin
-    implementation 'com.ryuta46:nem-kotlin:0.2.0'
+    implementation 'com.ryuta46:nem-kotlin:0.3.1'
 
     // depended libraries
     implementation 'com.madgag.spongycastle:prov:1.51.0.0'

--- a/src/main/kotlin/com/ryuta46/nemkotlin/net/HttpURLConnectionClient.kt
+++ b/src/main/kotlin/com/ryuta46/nemkotlin/net/HttpURLConnectionClient.kt
@@ -37,8 +37,9 @@ class HttpURLConnectionClient : HttpClient {
 
         try {
             connection.requestMethod = request.method
-            request.properties.forEach { key, value ->
-                connection.setRequestProperty(key, value)
+
+            for (entry in request.properties) {
+                connection.setRequestProperty(entry.key, entry.value)
             }
 
             if (request.body.isNotEmpty()) {


### PR DESCRIPTION
Version 0.3.1
* Fix: HttpURLConnectionClient doesn't work on Android when the API level is lower than 24.